### PR TITLE
Windows compilation fix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,12 +3,14 @@ stages:
 - test
 - deploy
 
+
 variables:
   VERSION: 0.3.14
   VERUS_CLI_LINUX: "Verus-CLI-Linux-v${VERSION}-beta.tar.gz"
   VERUS_CLI_WINDOWS: "Verus-CLI-Windows-v${VERSION}-beta.zip"
   VERUS_CLI_MACOS: "Verus-CLI-MacOS-v${VERSION}-beta.tar.gz"
   POST_COMMENT: "Branch and Commit: ${CI_COMMIT_REF_NAME} ${CI_COMMIT_SHA} $'\n'MD5: "
+
 
 build:linux:
   image: asherd/veruscoin-cross-compiler:linux
@@ -19,7 +21,7 @@ build:linux:
   - rm -rf /root/.ccache || true
   - mv .ccache /root/ || true
   script:
-  - zcutil/build.sh -j4
+  - zcutil/build.sh -j$(nproc)
   - cp src/komodod src/komodo-cli kmd/linux/verus-cli
   - chmod +x kmd/linux/verus-cli/komodod
   - chmod +x kmd/linux/verus-cli/komodo-cli
@@ -30,6 +32,12 @@ build:linux:
   - cd kmd/linux/
   - tar -czvf $VERUS_CLI_LINUX verus-cli
   - mv $VERUS_CLI_LINUX ../..
+  - export VERUS_CLI_LINUX_MD5=$(md5sum $VERUS_CLI_LINUX | cut -d " " -f 1)
+  - curl -F file=@"$VERUS_CLI_LINUX"
+      -F channels="$CLI_POST_CHANNEL"
+      -F initial_comment="${POST_COMMENT}$VERUS_CLI_LINUX_MD5"
+      -H "${SLACK_BOT_AUTH}"
+      "https://slack.com/api/files.upload"
   after_script:
   - mv /root/.ccache ./ || true
   cache:
@@ -61,11 +69,17 @@ build:windows:
   - mkdir .cargo || echo .cargo exists
   - ln -s $PWD/.cargo /root/.cargo
   script:
-  - zcutil/build-win.sh -j4
+  - zcutil/build-win.sh -j$(nproc)
   - cp src/komodod.exe src/komodo-cli.exe src/komodo-tx.exe kmd/windows/verus-cli
   - cd kmd/windows/
   - zip -r $VERUS_CLI_WINDOWS verus-cli
   - mv $VERUS_CLI_WINDOWS ../..
+  - export VERUS_CLI_WINDOWS_MD5=$(md5sum $VERUS_CLI_WINDOWS | cut -d " " -f 1)
+  - curl -F file=@"$VERUS_CLI_WINDOWS"
+      -F channels="$CLI_POST_CHANNEL"
+      -F initial_comment="${POST_COMMENT}$VERUS_CLI_WINDOWS_MD5"
+      -H "${SLACK_BOT_AUTH}"
+      "https://slack.com/api/files.upload"
   artifacts:
     paths: [$VERUS_CLI_WINDOWS]
     expire_in: 1 week
@@ -80,10 +94,16 @@ build:mac:
     - depends/built
   script:
   - brew bundle
-  - zcutil/build-mac.sh -j6 | xcpretty
+  - zcutil/build-mac.sh -j$(sysctl -n hw.physicalcpu) | xcpretty
   - ./makeReleaseMac.sh
   - dos2unix kmd/mac/verus-cli/README.txt
   - tar -C kmd/mac/ -czvf $VERUS_CLI_MACOS verus-cli ./
+  - export VERUS_CLI_MACOS_MD5=$(md5sum $VERUS_CLI_MACOS | cut -d " " -f 1)
+  - curl -F file=@"$VERUS_CLI_MACOS"
+      -F channels="$CLI_POST_CHANNEL"
+      -F initial_comment="${POST_COMMENT}$VERUS_CLI_MACOS_MD5"
+      -H "${SLACK_BOT_AUTH}"
+      "https://slack.com/api/files.upload"
   artifacts:
     paths: [$VERUS_CLI_MACOS]
     expire_in: 1 week
@@ -123,7 +143,6 @@ build:mac:
       "registry.gitlab.com/gitlab-org/security-products/sast:$SP_VERSION" /app/bin/run /code
   artifacts:
     paths: [gl-sast-report.json]
-
 
 
 .license_management:
@@ -234,53 +253,29 @@ build:mac:
   - build:windows
 
 
-deploy:linux:
+deploy:
   stage: deploy
   image: google/cloud-sdk:alpine
   variables:
     DOCKER_DRIVER: overlay2
   dependencies:
   - build:linux
-  before_script:
-  - export VERUS_CLI_LINUX_MD5=$(md5sum $VERUS_CLI_LINUX | cut -d " " -f 1)
-  script:
-  - curl -F file=@"$VERUS_CLI_LINUX"
-      -F channels="$CLI_POST_CHANNEL"
-      -F initial_comment="${POST_COMMENT}$VERUS_CLI_LINUX_MD5"
-      -H "${SLACK_BOT_AUTH}"
-      "https://slack.com/api/files.upload"
-
-
-deploy:windows:
-  stage: deploy
-  image: google/cloud-sdk:alpine
-  variables:
-    DOCKER_DRIVER: overlay2
-  dependencies:
   - build:windows
-  before_script:
-  - export VERUS_CLI_WINDOWS_MD5=$(md5sum $VERUS_CLI_WINDOWS | cut -d " " -f 1)
-  script:
-  - curl -F file=@"$VERUS_CLI_WINDOWS"
-      -F channels="$CLI_POST_CHANNEL"
-      -F initial_comment="${POST_COMMENT}$VERUS_CLI_WINDOWS_MD5"
-      -H "${SLACK_BOT_AUTH}"
-      "https://slack.com/api/files.upload"
-
-      
-deploy:mac:
-  stage: deploy
-  image: google/cloud-sdk:alpine
-  variables:
-    DOCKER_DRIVER: overlay2
-  dependencies:
   - build:mac
-  before_script:
-  - export VERUS_CLI_MACOS_MD5=$(md5sum $VERUS_CLI_MACOS | cut -d " " -f 1)
   script:
-  - curl -F file=@"$VERUS_CLI_MACOS"
-      -F channels="$CLI_POST_CHANNEL"
-      -F initial_comment="${POST_COMMENT}$VERUS_CLI_MACOS_MD5"
-      -H "${SLACK_BOT_AUTH}"
-      "https://slack.com/api/files.upload"
-  
+  - mkdir Windows && mkdir Linux && mkdir MacOS &&
+    mv $VERUS_CLI_WINDOWS Windows &&
+    mv $VERUS_CLI_LINUX Linux &&
+    mv $VERUS_CLI_MACOS MacOS
+  - echo "$AUTH_KEY" > AUTH_KEY.json &&
+    gcloud auth activate-service-account
+    --key-file AUTH_KEY.json
+  - gsutil cp -r Windows Linux MacOS $STAGING/VerusCoin/$CI_COMMIT_REF_NAME/
+  - curl -X POST
+      -F token="$CI_JOB_TOKEN"
+      -F ref=dev
+      -F variables\[UPSTREAM_CLI_BRANCH\]="$CI_COMMIT_REF_NAME"
+      -F variables\[VERUS_CLI_LINUX\]="$VERUS_CLI_LINUX"
+      -F variables\[VERUS_CLI_WINDOWS\]="$VERUS_CLI_WINDOWS"
+      -F variables\[VERUS_CLI_MACOS\]="$VERUS_CLI_MACOS"
+      "https://gitlab.com/api/v4/projects/8018592/trigger/pipeline"

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -7,6 +7,9 @@
 
 #include <string>
 #include <stdint.h>
+#ifdef _WIN32
+#undef __cpuid
+#endif
 #include <boost/thread.hpp>
 #include <boost/scoped_ptr.hpp>
 #include <boost/function.hpp>

--- a/src/script/sigcache.cpp
+++ b/src/script/sigcache.cpp
@@ -9,7 +9,9 @@
 #include "random.h"
 #include "uint256.h"
 #include "util.h"
-
+#ifdef _WIN32
+#undef __cpuid
+#endif
 #include <boost/thread.hpp>
 #include <boost/tuple/tuple_comparison.hpp>
 


### PR DESCRIPTION
Removing __cpuid definition when compiling for Windows to avoid conflicting definitions of __cpuid provided by gcc and intrin.h .
Updating GitLab yml to deploy to Slack during the build step for manual testing.