### PR TITLE
Fix mistake in build-mac-arm.sh MACOSX_DEPLOYMENT_TARGET variable

### DIFF
--- a/zcutil/build-mac-arm.sh
+++ b/zcutil/build-mac-arm.sh
@@ -43,7 +43,7 @@ fi
 TRIPLET=`./depends/config.guess`
 PREFIX="$(pwd)/depends/$TRIPLET"
 
-make "$@" -C ./depends v=1 NO_PROTON=1 NO_QT=1 HOST=aarch64-apple-darwin
+MACOSX_DEPLOYMENT_TARGET=13.0 make "$@" -C ./depends v=1 NO_PROTON=1 NO_QT=1 HOST=aarch64-apple-darwin
 ./autogen.sh
 
 # -mcpu=apple-m2 -mcpu=apple-m3 -mcpu=apple-m4 for M2, M3, M4 optimizations
@@ -54,4 +54,4 @@ export CXXFLAGS="-DSSE2NEON_SUPPRESS_WARNINGS -mcpu=apple-m1 -O2 \
 export CFLAGS="-DSSE2NEON_SUPPRESS_WARNINGS -mcpu=apple-m1 -O2"
 
 CONFIG_SITE="$PWD/depends/aarch64-apple-darwin/share/config.site" ./configure --enable-tests --disable-bench --with-gui=no --host=aarch64-apple-darwin "$HARDENING_ARG" "$LCOV_ARG" "$DEBUGGING_ARG"
-MACOSX_DEPLOYMENT_TARGET=10.5 make "$@" STATIC=1
+MACOSX_DEPLOYMENT_TARGET=13.0 make "$@" STATIC=1


### PR DESCRIPTION
Fixes a mistake in `MACOSX_DEPLOYMENT_TARGET` variable, and ensures the variable is also set while building depends. This ensures the `komodo-test` binary is built using the same minimum OSX version as `verusd`.

The previous `10.5` value is invalid on ARM builds which was resulting in `15.0` being used as default.