### PR TITLE
Introduce KOMODO_MININGTHREADS for mining configuration

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -75,6 +75,7 @@ using namespace std;
 
 extern void ThreadSendAlert();
 extern int32_t KOMODO_LOADINGBLOCKS;
+extern int32_t KOMODO_MININGTHREADS;
 extern bool VERUS_MINTBLOCKS;
 extern CTxDestination VERUS_DEFAULT_ARBADDRESS;
 extern std::vector<uint160> VERUS_ARBITRAGE_CURRENCIES;
@@ -559,7 +560,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-acceptfreeimportsfrom=<i-address>,<i-address>,...", _(" \"%s\" no spaces - accept underpaid imports from these PBaaS chains or networks - default is empty"));
     strUsage += HelpMessageOpt("-allowdelayednotarizations", strprintf(_("Do not notarize in order to prevent slower notarizations (default = %u, notarize to prevent slowing down)"), DEFAULT_SPENTINDEX));
     strUsage += HelpMessageOpt("-alwayssubmitnotarizations", strprintf(_("Submit notarizations to notary chain whenevever merge mining/staking and eligible (default = %u, only as needed)"), DEFAULT_SPENTINDEX));
-    strUsage += HelpMessageOpt("-approvecontractupgrade=<ETHcontracthash(0x...)>", strprintf(_("When validating blocks, vote to agree to upgrade to the specific contract. Default is no upgrade.")));
+    strUsage += HelpMessageOpt("-approvecontractupgrade=<0xf09...>", strprintf(_("When validating blocks, vote to agree to upgrade to the specific contract. Default is no upgrade.")));
     strUsage += HelpMessageOpt("-blocktime=<n>", strprintf(_("Set target block time (in seconds) for difficulty adjustment (default: %d)"), CCurrencyDefinition::DEFAULT_BLOCKTIME_TARGET));
     strUsage += HelpMessageOpt("-chain=pbaaschainname", _("loads either mainnet or resolves and loads a PBaaS chain if not vrsc or vrsctest"));
     strUsage += HelpMessageOpt("-miningdistributionpassthrough", _("uses the same miningdistribution values and addresses/IDs as Verus when merge mining"));
@@ -2350,11 +2351,10 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     VERUS_MINTBLOCKS = GetBoolArg("-mint", false);
     mapArgs["-gen"] = gen || VERUS_MINTBLOCKS ? "1" : "0";
     mapArgs["-genproclimit"] = itostr(GetArg("-genproclimit", gen ? -1 : 0));
-
-    if (pwalletMain || !GetArg("-mineraddress", "").empty())
-        GenerateBitcoins(gen || VERUS_MINTBLOCKS, pwalletMain, GetArg("-genproclimit", gen ? -1 : 0));
+    // Update KOMODO_MININGTHREADS here since komodo_args runs before config file is read
+    KOMODO_MININGTHREADS = GetArg("-genproclimit", gen ? -1 : 0);
  #else
-    GenerateBitcoins(gen, GetArg("-genproclimit", -1));
+    KOMODO_MININGTHREADS = GetArg("-genproclimit", gen ? -1 : 0);
  #endif
 #endif
 
@@ -2367,6 +2367,17 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     SetRPCWarmupFinished();
     uiInterface.InitMessage(_("Done loading"));
+
+#ifdef ENABLE_MINING
+    // Start mining after RPC is warmed up and node is fully initialized
+    // This prevents potential hangs from mining threads waiting for initialization
+ #ifdef ENABLE_WALLET
+    if (pwalletMain || !GetArg("-mineraddress", "").empty())
+        GenerateBitcoins(gen || VERUS_MINTBLOCKS, pwalletMain, KOMODO_MININGTHREADS);
+ #else
+    GenerateBitcoins(gen, KOMODO_MININGTHREADS);
+ #endif
+#endif
 
 #ifdef ENABLE_WALLET
     if (pwalletMain) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -560,7 +560,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-acceptfreeimportsfrom=<i-address>,<i-address>,...", _(" \"%s\" no spaces - accept underpaid imports from these PBaaS chains or networks - default is empty"));
     strUsage += HelpMessageOpt("-allowdelayednotarizations", strprintf(_("Do not notarize in order to prevent slower notarizations (default = %u, notarize to prevent slowing down)"), DEFAULT_SPENTINDEX));
     strUsage += HelpMessageOpt("-alwayssubmitnotarizations", strprintf(_("Submit notarizations to notary chain whenevever merge mining/staking and eligible (default = %u, only as needed)"), DEFAULT_SPENTINDEX));
-    strUsage += HelpMessageOpt("-approvecontractupgrade=<0xf09...>", strprintf(_("When validating blocks, vote to agree to upgrade to the specific contract. Default is no upgrade.")));
+    strUsage += HelpMessageOpt("-approvecontractupgrade=<ETHcontracthash(0x...)>", strprintf(_("When validating blocks, vote to agree to upgrade to the specific contract. Default is no upgrade.")));
     strUsage += HelpMessageOpt("-blocktime=<n>", strprintf(_("Set target block time (in seconds) for difficulty adjustment (default: %d)"), CCurrencyDefinition::DEFAULT_BLOCKTIME_TARGET));
     strUsage += HelpMessageOpt("-chain=pbaaschainname", _("loads either mainnet or resolves and loads a PBaaS chain if not vrsc or vrsctest"));
     strUsage += HelpMessageOpt("-miningdistributionpassthrough", _("uses the same miningdistribution values and addresses/IDs as Verus when merge mining"));


### PR DESCRIPTION
## Fix: Mining Configuration Not Applied from Config File

### Problem

When setting mining parameters in `VRSC.conf`:
```ini
gen=1
genproclimit=1
mint=1
```

The daemon would:
1. Show `"numthreads": 0` in `getmininginfo` 
2. Potentially hang on startup

However, manually running `./verus setgenerate true 1` after startup worked correctly.

### Root Cause

The `komodo_args()` function runs **before** the configuration file is loaded.

In bitcoind.cpp:

| Line | Code | Description |
|------|------|-------------|
| 113 | `ParseParameters(argc, argv)` | Command-line args parsed |
| 142 | `komodo_args(argv[0])` | Sets `KOMODO_MININGTHREADS` |
| 161 | `ReadConfigFile(mapArgs, mapMultiArgs)` | **Config file loaded here** |

When `komodo_args()` executes (line 142), it checks for `-gen` in `komodo_utils.h:1746-1750`:

```cpp
if ( GetBoolArg("-gen", false) != 0 )
{
    KOMODO_MININGTHREADS = GetArg("-genproclimit",-1);
}
else KOMODO_MININGTHREADS = 0;
```

At this point, `mapArgs` only contains **command-line arguments**. Config file settings (`gen=1`, `genproclimit=1`, `mint=1`) haven't been loaded yet.

Since `-gen` isn't found, `KOMODO_MININGTHREADS` is set to `0` and never updated.

### Solution

1. **Added `extern` declaration** for `KOMODO_MININGTHREADS` in init.cpp
2. **Set `KOMODO_MININGTHREADS`** in init.cpp after the config file has been read
3. **Moved `GenerateBitcoins()` call** to after `SetRPCWarmupFinished()` to ensure the node is fully initialized before starting mining threads

### Changes

**init.cpp:**
- Added `extern int32_t KOMODO_MININGTHREADS;` declaration
- Set `KOMODO_MININGTHREADS` from config after it's loaded
- Deferred `GenerateBitcoins()` until after RPC warmup completes

---