### PR TITLE
Three violation classes 

### DIFF
--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -1482,58 +1482,41 @@ UniValue CRating::ToUniValue() const
 UniValue CMMRProof::ToUniValue() const
 {
     UniValue retObj(UniValue::VOBJ);
-    for (auto &proof : proofSequence)
+    for (const auto& entry : proofSequence)
     {
         UniValue branchArray(UniValue::VARR);
-        switch (proof->branchType)
+        if (const auto* p = std::get_if<CBTCMerkleBranch>(&entry))
         {
-            case CMerkleBranchBase::BRANCH_BTC:
-            {
-                CBTCMerkleBranch &branch = *(CBTCMerkleBranch *)(proof);
-                retObj.push_back(Pair("branchtype", (int)CMerkleBranchBase::BRANCH_BTC));
-                retObj.push_back(Pair("index", (int64_t)(branch.nIndex)));
-                for (auto &oneHash : branch.branch)
-                {
-                    branchArray.push_back(oneHash.GetHex());
-                }
-                retObj.push_back(Pair("hashes", branchArray));
-                break;
-            }
-            case CMerkleBranchBase::BRANCH_MMRBLAKE_NODE:
-            {
-                CMMRNodeBranch &branch = *(CMMRNodeBranch *)(proof);
-                retObj.push_back(Pair("branchtype", (int)CMerkleBranchBase::BRANCH_MMRBLAKE_NODE));
-                retObj.push_back(Pair("index", (int64_t)(branch.nIndex)));
-                retObj.push_back(Pair("mmvsize", (int64_t)(branch.nSize)));
-                for (auto &oneHash : branch.branch)
-                {
-                    branchArray.push_back(oneHash.GetHex());
-                }
-                retObj.push_back(Pair("hashes", branchArray));
-                break;
-            }
-            case CMerkleBranchBase::BRANCH_MMRBLAKE_POWERNODE:
-            {
-                CMMRPowerNodeBranch &branch = *(CMMRPowerNodeBranch *)(proof);
-                retObj.push_back(Pair("branchtype", (int)CMerkleBranchBase::BRANCH_MMRBLAKE_POWERNODE));
-                retObj.push_back(Pair("index", (int64_t)(branch.nIndex)));
-                retObj.push_back(Pair("mmvsize", (int64_t)(branch.nSize)));
-                for (auto &oneHash : branch.branch)
-                {
-                    branchArray.push_back(oneHash.GetHex());
-                }
-                retObj.push_back(Pair("hashes", branchArray));
-                break;
-            }
-            case CMerkleBranchBase::BRANCH_ETH:
-            {
-                CETHPATRICIABranch &branch = *(CETHPATRICIABranch *)(proof);
-                retObj.push_back(Pair("branchtype", (int)CMerkleBranchBase::BRANCH_ETH));
-                // univalue of ETH proof is just hex of whole object
-                std::vector<unsigned char> serBytes(::AsVector(*this));
-                retObj.push_back(Pair("data", HexBytes(&(serBytes[0]), serBytes.size())));
-            }
-        };
+            retObj.push_back(Pair("branchtype", (int)CMerkleBranchBase::BRANCH_BTC));
+            retObj.push_back(Pair("index", (int64_t)(p->nIndex)));
+            for (auto &oneHash : p->branch)
+                branchArray.push_back(oneHash.GetHex());
+            retObj.push_back(Pair("hashes", branchArray));
+        }
+        else if (const auto* p = std::get_if<CMMRNodeBranch>(&entry))
+        {
+            retObj.push_back(Pair("branchtype", (int)CMerkleBranchBase::BRANCH_MMRBLAKE_NODE));
+            retObj.push_back(Pair("index", (int64_t)(p->nIndex)));
+            retObj.push_back(Pair("mmvsize", (int64_t)(p->nSize)));
+            for (auto &oneHash : p->branch)
+                branchArray.push_back(oneHash.GetHex());
+            retObj.push_back(Pair("hashes", branchArray));
+        }
+        else if (const auto* p = std::get_if<CMMRPowerNodeBranch>(&entry))
+        {
+            retObj.push_back(Pair("branchtype", (int)CMerkleBranchBase::BRANCH_MMRBLAKE_POWERNODE));
+            retObj.push_back(Pair("index", (int64_t)(p->nIndex)));
+            retObj.push_back(Pair("mmvsize", (int64_t)(p->nSize)));
+            for (auto &oneHash : p->branch)
+                branchArray.push_back(oneHash.GetHex());
+            retObj.push_back(Pair("hashes", branchArray));
+        }
+        else if (std::holds_alternative<CETHPATRICIABranch>(entry))
+        {
+            retObj.push_back(Pair("branchtype", (int)CMerkleBranchBase::BRANCH_ETH));
+            std::vector<unsigned char> serBytes(::AsVector(*this));
+            retObj.push_back(Pair("data", HexBytes(&(serBytes[0]), serBytes.size())));
+        }
     }
     return retObj;
 }

--- a/src/mmr.cpp
+++ b/src/mmr.cpp
@@ -21,7 +21,9 @@ CMultiPartProof::CMultiPartProof(const std::vector<CMMRProof> &chunkVec) : CMerk
     for (const CMMRProof &oneChunk : chunkVec)
     {
         assert(oneChunk.IsMultiPart());
-        vch.insert(vch.end(), ((CMultiPartProof *)oneChunk.proofSequence[0])->vch.begin(), ((CMultiPartProof *)oneChunk.proofSequence[0])->vch.end());
+        const auto* p = std::get_if<CMultiPartProof>(&oneChunk.proofSequence[0]);
+        assert(p);
+        vch.insert(vch.end(), p->vch.begin(), p->vch.end());
     }
 }
 
@@ -54,7 +56,9 @@ std::vector<CMMRProof> CMultiPartProof::BreakToChunks(int maxSize) const
         }
         else
         {
-            std::vector<unsigned char> &oneChunkVec = ((CMultiPartProof *)oneChunk.proofSequence[0])->vch;
+            auto* pEntry = std::get_if<CMultiPartProof>(&oneChunk.proofSequence[0]);
+            assert(pEntry);
+            std::vector<unsigned char> &oneChunkVec = pEntry->vch;
             oneChunkVec.erase(oneChunkVec.begin() + (oneChunkVec.size() - removeBytes), oneChunkVec.end());
             bytesLeft -= oneChunkVec.size();
             curIndex += oneChunkVec.size();
@@ -66,204 +70,87 @@ std::vector<CMMRProof> CMultiPartProof::BreakToChunks(int maxSize) const
 
 void CMMRProof::DeleteProofSequenceEntry(int index)
 {
-    if (index >= 0 && index < proofSequence.size())
-    {
-        CMerkleBranchBase *pProof = proofSequence[index];
-        switch(pProof->branchType)
-        {
-            case CMerkleBranchBase::BRANCH_BTC:
-            {
-                delete (CBTCMerkleBranch *)pProof;
-                break;
-            }
-            case CMerkleBranchBase::BRANCH_MMRBLAKE_NODE:
-            {
-                delete (CMMRNodeBranch *)pProof;
-                break;
-            }
-            case CMerkleBranchBase::BRANCH_MMRBLAKE_POWERNODE:
-            {
-                delete (CMMRPowerNodeBranch *)pProof;
-                break;
-            }
-            case CMerkleBranchBase::BRANCH_ETH:
-            {
-                delete (CETHPATRICIABranch *)pProof;
-                break;
-            }
-            case CMerkleBranchBase::BRANCH_MULTIPART:
-            {
-                delete (CMultiPartProof *)pProof;
-                break;
-            }
-            default:
-            {
-                ErrorAndBP("ERROR: likely double-free or memory corruption, unrecognized object in proof sequence");
-                // this is likely a memory error
-                // delete pProof;
-            }
-        }
+    if (index >= 0 && index < (int)proofSequence.size())
         proofSequence.erase(proofSequence.begin() + index);
-    }
 }
 
 void CMMRProof::DeleteProofSequence()
 {
-    // delete any objects that may be present
-    for (int i = proofSequence.size() - 1; i >= 0 && proofSequence[i]; i--)
-    {
-        CMerkleBranchBase *pProof = proofSequence[i];
-        switch(pProof->branchType)
-        {
-            case CMerkleBranchBase::BRANCH_BTC:
-            {
-                delete (CBTCMerkleBranch *)pProof;
-                break;
-            }
-            case CMerkleBranchBase::BRANCH_MMRBLAKE_NODE:
-            {
-                delete (CMMRNodeBranch *)pProof;
-                break;
-            }
-            case CMerkleBranchBase::BRANCH_MMRBLAKE_POWERNODE:
-            {
-                delete (CMMRPowerNodeBranch *)pProof;
-                break;
-            }
-            case CMerkleBranchBase::BRANCH_ETH:
-            {
-                delete (CETHPATRICIABranch *)pProof;
-                break;
-            }
-            case CMerkleBranchBase::BRANCH_MULTIPART:
-            {
-                delete (CMultiPartProof *)pProof;
-                break;
-            }
-            default:
-            {
-                ErrorAndBP("ERROR: likely double-free or memory corruption, unrecognized object in proof sequence");
-                // this is likely a memory error
-                // delete pProof;
-            }
-        }
-        proofSequence.pop_back();
-    }
+    proofSequence.clear();
 }
 
 const CMMRProof &CMMRProof::operator<<(const CBTCMerkleBranch &append)
 {
-    CMerkleBranchBase *pNewProof = new CBTCMerkleBranch(append);
-    pNewProof->branchType = CMerkleBranchBase::BRANCH_BTC;
-    proofSequence.push_back(pNewProof);
+    proofSequence.emplace_back(append);
     return *this;
 }
 
 const CMMRProof &CMMRProof::operator<<(const CMMRNodeBranch &append)
 {
-    CMerkleBranchBase *pNewProof = new CMMRNodeBranch(append);
-    pNewProof->branchType = CMerkleBranchBase::BRANCH_MMRBLAKE_NODE;
-    proofSequence.push_back(pNewProof);
+    proofSequence.emplace_back(append);
     return *this;
 }
 
 const CMMRProof &CMMRProof::operator<<(const CMMRPowerNodeBranch &append)
 {
-    CMerkleBranchBase *pNewProof = new CMMRPowerNodeBranch(append);
-    pNewProof->branchType = CMerkleBranchBase::BRANCH_MMRBLAKE_POWERNODE;
-    proofSequence.push_back(pNewProof);
+    proofSequence.emplace_back(append);
     return *this;
 }
 
 const CMMRProof &CMMRProof::operator<<(const CETHPATRICIABranch &append)
 {
-    CETHPATRICIABranch *pNewProof = new CETHPATRICIABranch(append);
-    pNewProof->branchType = CMerkleBranchBase::BRANCH_ETH;
-    proofSequence.push_back(pNewProof);
+    proofSequence.emplace_back(append);
     return *this;
 }
 
 const CMMRProof &CMMRProof::operator<<(const CMultiPartProof &append)
 {
-    CMultiPartProof *pNewProof = new CMultiPartProof(append);
-    proofSequence.push_back(pNewProof);
+    proofSequence.emplace_back(append);
     return *this;
 }
 
 uint160 CMMRProof::GetNativeAddress() const
 {
     uint160 retAddress;
-    for (auto &pProof : proofSequence)
+    for (const auto& entry : proofSequence)
     {
-        switch(pProof->branchType)
-        {
-            case CMerkleBranchBase::BRANCH_ETH:
-            {
-                retAddress = ((CETHPATRICIABranch *)pProof)->address;
-                break;
-            }
-            default:
-            {
-                return uint160();
-            }
-        }
+        if (const auto* p = std::get_if<CETHPATRICIABranch>(&entry))
+            retAddress = p->address;
+        else
+            return uint160();
     }
     return retAddress;
 }
 
 bool CMMRProof::CheckStorageKey(uint32_t height) const
 {
-    for (auto &pProof : proofSequence)
+    for (const auto& entry : proofSequence)
     {
-        switch(pProof->branchType)
-        {
-            case CMerkleBranchBase::BRANCH_ETH:
-            {
-                return ((CETHPATRICIABranch *)pProof)->CheckStorageKeyHash(height);
-            }
-            default:
-            {
-                return false;
-            }
-        }
+        if (const auto* p = std::get_if<CETHPATRICIABranch>(&entry))
+            return p->CheckStorageKeyHash(height);
+        else
+            return false;
     }
     return false;
 }
 
 uint256 CMMRProof::CheckProof(uint256 hash, bool optimized) const
 {
-    for (auto &pProof : proofSequence)
+    for (const auto& entry : proofSequence)
     {
-        switch(pProof->branchType)
+        if (const auto* p = std::get_if<CBTCMerkleBranch>(&entry))
+            hash = p->SafeCheck(hash);
+        else if (const auto* p = std::get_if<CMMRNodeBranch>(&entry))
+            hash = p->SafeCheck(hash);
+        else if (const auto* p = std::get_if<CMMRPowerNodeBranch>(&entry))
+            hash = p->SafeCheck(hash);
+        else if (const auto* p = std::get_if<CETHPATRICIABranch>(&entry))
         {
-            case CMerkleBranchBase::BRANCH_BTC:
-            {
-                hash = ((CBTCMerkleBranch *)pProof)->SafeCheck(hash);
-                break;
-            }
-            case CMerkleBranchBase::BRANCH_MMRBLAKE_NODE:
-            {
-                hash = ((CMMRNodeBranch *)pProof)->SafeCheck(hash);
-                //printf("Result from CMMRNodeBranch check: %s\n", hash.GetHex().c_str());
-                break;
-            }
-            case CMerkleBranchBase::BRANCH_MMRBLAKE_POWERNODE:
-            {
-                hash = ((CMMRPowerNodeBranch *)pProof)->SafeCheck(hash);
-                //printf("Result from CMMRPowerNodeBranch check: %s\n", hash.GetHex().c_str());
-                break;
-            }
-            case CMerkleBranchBase::BRANCH_ETH:
-            {
-                hash = ((CETHPATRICIABranch *)pProof)->SafeCheck(hash, optimized);
-                LogPrint("crosschain", "Result from ETHBranch check: %s\n", hash.GetHex().c_str());
-                break;
-            }
-            default:
-            {
-                return uint256();
-            }
+            hash = p->SafeCheck(hash, optimized);
+            LogPrint("crosschain", "Result from ETHBranch check: %s\n", hash.GetHex().c_str());
         }
+        else
+            return uint256();
     }
     return hash;
 }

--- a/src/mmr.h
+++ b/src/mmr.h
@@ -19,6 +19,7 @@
 #ifndef MMR_H
 #define MMR_H
 
+#include <variant>
 #include <vector>
 #include <univalue.h>
 
@@ -688,32 +689,21 @@ public:
 class CMMRProof
 {
 public:
-    std::vector<CMerkleBranchBase *> proofSequence;
+    using ProofEntry = std::variant<CBTCMerkleBranch, CMMRNodeBranch, CMMRPowerNodeBranch, CETHPATRICIABranch, CMultiPartProof>;
+    std::vector<ProofEntry> proofSequence;
 
-    CMMRProof() {}
-    CMMRProof(const CMMRProof &oldProof)
-    {
-        CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
-        s << oldProof;
-        DeleteProofSequence();
-        s >> *this;
-    }
-    const CMMRProof &operator=(const CMMRProof &operand)
-    {
-        CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
-        s << operand;
-        DeleteProofSequence();
-        s >> *this;
-        return *this;
-    }
+    CMMRProof() = default;
+    CMMRProof(const CMMRProof &) = default;
+    CMMRProof(CMMRProof &&) = default;
+    CMMRProof &operator=(const CMMRProof &) = default;
+    CMMRProof &operator=(CMMRProof &&) = default;
 
-    ~CMMRProof()
+    void DeleteProofSequence() { proofSequence.clear(); }
+    void DeleteProofSequenceEntry(int index)
     {
-        DeleteProofSequence();
+        if (index >= 0 && index < (int)proofSequence.size())
+            proofSequence.erase(proofSequence.begin() + index);
     }
-
-    void DeleteProofSequence();
-    void DeleteProofSequenceEntry(int index);
 
     ADD_SERIALIZE_METHODS;
     
@@ -723,78 +713,50 @@ public:
         {
             int32_t proofSize;
             READWRITE(proofSize);
-
-            // in case it is deserialized with something present
-            DeleteProofSequence();
-
+            proofSequence.clear();
             bool error = false;
             for (int i = 0; i < proofSize && !error; i++)
             {
                 uint8_t branchType = 0;
-                union {
-                    CBTCMerkleBranch *pBranch;
-                    CMMRNodeBranch *pNodeBranch;
-                    CMMRPowerNodeBranch *pPowerNodeBranch;
-                    CMerkleBranchBase *pobj;
-                    CETHPATRICIABranch *pETHBranch;
-                    CMultiPartProof *pMultiProofBranch;
-                };
-
-                // non-error exception comes from the first try on each object. after this, it is an error
-                pobj = nullptr;
-                bool manualDelete = false;
-
+                bool emplaced = false;
                 try
                 {
-                    // our normal way out is an exception at end of stream
-                    // would prefer a better way
                     READWRITE(branchType);
-
                     switch(branchType)
                     {
                         case CMerkleBranchBase::BRANCH_BTC:
                         {
-                            pBranch = new CBTCMerkleBranch();
-                            if (pBranch)
-                            {
-                                READWRITE(*pBranch);
-                            }
+                            proofSequence.emplace_back(std::in_place_type<CBTCMerkleBranch>);
+                            emplaced = true;
+                            READWRITE(std::get<CBTCMerkleBranch>(proofSequence.back()));
                             break;
                         }
                         case CMerkleBranchBase::BRANCH_MMRBLAKE_NODE:
                         {
-                            pNodeBranch = new CMMRNodeBranch();
-                            if (pNodeBranch)
-                            {
-                                READWRITE(*pNodeBranch);
-                            }
+                            proofSequence.emplace_back(std::in_place_type<CMMRNodeBranch>);
+                            emplaced = true;
+                            READWRITE(std::get<CMMRNodeBranch>(proofSequence.back()));
                             break;
                         }
                         case CMerkleBranchBase::BRANCH_MMRBLAKE_POWERNODE:
                         {
-                            pPowerNodeBranch = new CMMRPowerNodeBranch();
-                            if (pPowerNodeBranch)
-                            {
-                                READWRITE(*pPowerNodeBranch);
-                            }
+                            proofSequence.emplace_back(std::in_place_type<CMMRPowerNodeBranch>);
+                            emplaced = true;
+                            READWRITE(std::get<CMMRPowerNodeBranch>(proofSequence.back()));
                             break;
                         }
                         case CMerkleBranchBase::BRANCH_ETH:
                         {
-                            pETHBranch = new CETHPATRICIABranch();
-                            if (pETHBranch)
-                            {
-                                READWRITE(*pETHBranch);
-                            }
+                            proofSequence.emplace_back(std::in_place_type<CETHPATRICIABranch>);
+                            emplaced = true;
+                            READWRITE(std::get<CETHPATRICIABranch>(proofSequence.back()));
                             break;
                         }
                         case CMerkleBranchBase::BRANCH_MULTIPART:
                         {
-                            pMultiProofBranch = new CMultiPartProof();
-                            if (pMultiProofBranch)
-                            {
-                                READWRITE(*pMultiProofBranch);
-                            }
+                            proofSequence.emplace_back(std::in_place_type<CMultiPartProof>);
+                            emplaced = true;
+                            READWRITE(std::get<CMultiPartProof>(proofSequence.back()));
                             break;
                         }
                         default:
@@ -804,118 +766,66 @@ public:
                             error = true;
                         }
                     }
-
-                    if (pobj)
+                    if (!error && emplaced)
                     {
-                        if (pobj->branchType == branchType)
+                        uint8_t actualType = std::visit([](const auto& b) -> uint8_t { return b.branchType; }, proofSequence.back());
+                        if (actualType != branchType)
                         {
-                            proofSequence.push_back(pobj);
-                        }
-                        else
-                        {
-                            manualDelete = true;
+                            proofSequence.pop_back();
+                            error = true;
                         }
                     }
                 }
                 catch(const std::exception& e)
                 {
                     error = true;
-                    if (pobj)
-                    {
-                        manualDelete = true;
-                    }
-                }
-
-                if (manualDelete)
-                {
-                    error = true;
-                    switch(branchType)
-                    {
-                        case CMerkleBranchBase::BRANCH_BTC:
-                        {
-                            delete pBranch;
-                            break;
-                        }
-                        case CMerkleBranchBase::BRANCH_MMRBLAKE_NODE:
-                        {
-                            delete pNodeBranch;
-                            break;
-                        }
-                        case CMerkleBranchBase::BRANCH_MMRBLAKE_POWERNODE:
-                        {
-                            delete pPowerNodeBranch;
-                            break;
-                        }
-                        case CMerkleBranchBase::BRANCH_ETH:
-                        {
-                            delete pETHBranch;
-                            break;
-                        }
-                        case CMerkleBranchBase::BRANCH_MULTIPART:
-                        {
-                            delete pMultiProofBranch;
-                            break;
-                        }
-                        default:
-                        {
-                            printf("%s: ERROR: should never get here - proof sequence is likely corrupt, code %d\n", __func__, branchType);
-                            LogPrintf("%s: ERROR: should never get here - proof sequence is likely corrupt, code %d\n", __func__, branchType);
-                        }
-                    }
-                    pobj = nullptr;
+                    if (emplaced)
+                        proofSequence.pop_back();
                 }
             }
-
             if (error)
             {
                 printf("%s: ERROR: failure - proof sequence is likely corrupt\n", __func__);
                 LogPrintf("%s: ERROR: failure - proof sequence is likely corrupt\n", __func__);
-                DeleteProofSequence();
+                proofSequence.clear();
             }
         }
         else
         {
             int32_t proofSize = proofSequence.size();
             READWRITE(proofSize);
-
-            for (auto pProof : proofSequence)
+            for (auto& entry : proofSequence)
             {
                 bool error = false;
-                READWRITE(pProof->branchType);
-
-                switch(pProof->branchType)
+                if (auto* p = std::get_if<CBTCMerkleBranch>(&entry))
                 {
-                    case CMerkleBranchBase::BRANCH_BTC:
-                    {
-                        READWRITE(*(CBTCMerkleBranch *)pProof);
-                        break;
-                    }
-                    case CMerkleBranchBase::BRANCH_MMRBLAKE_NODE:
-                    {
-                        READWRITE(*(CMMRNodeBranch *)pProof);
-                        break;
-                    }
-                    case CMerkleBranchBase::BRANCH_MMRBLAKE_POWERNODE:
-                    {
-                        READWRITE(*(CMMRPowerNodeBranch *)pProof);
-                        break;
-                    }
-                    case CMerkleBranchBase::BRANCH_ETH:
-                    {
-                        READWRITE(*(CETHPATRICIABranch *)pProof);
-                        break;
-                    }
-                    case CMerkleBranchBase::BRANCH_MULTIPART:
-                    {
-                        READWRITE(*(CMultiPartProof *)pProof);
-                        break;
-                    }
-                    default:
-                    {
-                        error = true;
-                        printf("ERROR: unknown branch type (%u), likely corrupt\n", pProof->branchType);
-                        break;
-                    }
+                    READWRITE(p->branchType);
+                    READWRITE(*p);
+                }
+                else if (auto* p = std::get_if<CMMRNodeBranch>(&entry))
+                {
+                    READWRITE(p->branchType);
+                    READWRITE(*p);
+                }
+                else if (auto* p = std::get_if<CMMRPowerNodeBranch>(&entry))
+                {
+                    READWRITE(p->branchType);
+                    READWRITE(*p);
+                }
+                else if (auto* p = std::get_if<CETHPATRICIABranch>(&entry))
+                {
+                    READWRITE(p->branchType);
+                    READWRITE(*p);
+                }
+                else if (auto* p = std::get_if<CMultiPartProof>(&entry))
+                {
+                    READWRITE(p->branchType);
+                    READWRITE(*p);
+                }
+                else
+                {
+                    error = true;
+                    printf("ERROR: unknown branch type in proof sequence, likely corrupt\n");
                 }
                 assert(!error);
             }
@@ -929,7 +839,7 @@ public:
     const CMMRProof &operator<<(const CMultiPartProof &append);
     bool IsMultiPart() const
     {
-        return proofSequence.size() == 1 && proofSequence[0]->branchType == CMerkleBranchBase::BRANCH_MULTIPART;
+        return proofSequence.size() == 1 && std::holds_alternative<CMultiPartProof>(proofSequence[0]);
     }
     uint256 CheckProof(uint256 checkHash, bool optimized=true) const;
     uint160 GetNativeAddress() const;

--- a/src/pbaas/notarization.cpp
+++ b/src/pbaas/notarization.cpp
@@ -5757,17 +5757,19 @@ bool ProvePosBlock(uint32_t lastProofRootHeight, const CBlockIndex *pindex, CNot
         uint256 txHash = checkProof.GetPartialTransaction(checkTx);
         uint256 merkleRoot = checkProof.CheckPartialTransaction(checkTx);
 
-        uint32_t shiftIndex = ((CBTCMerkleBranch *)(checkProof.txProof.proofSequence[0]))->nIndex;
+        const auto* pBranch = std::get_if<CBTCMerkleBranch>(&checkProof.txProof.proofSequence[0]);
+        assert(pBranch);
+        uint32_t shiftIndex = pBranch->nIndex;
         LogPrintf("%s: Checking stake transaction proof\nMerkle branch:\nindex: %d\n", __func__, shiftIndex);
 
-        for (auto oneHash : ((CBTCMerkleBranch *)(checkProof.txProof.proofSequence[0]))->branch)
+        for (auto oneHash : pBranch->branch)
         {
             LogPrintf("hash on %s: %s\n", shiftIndex & 1 ? "left" : "right", oneHash.GetHex().c_str());
             shiftIndex >>= 1;
         }
 
         uint256 checkMerkle =
-            SafeCheckMerkleBranch(txHash, ((CBTCMerkleBranch *)(checkProof.txProof.proofSequence[0]))->branch, ((CBTCMerkleBranch *)(checkProof.txProof.proofSequence[0]))->nIndex);
+            SafeCheckMerkleBranch(txHash, pBranch->branch, pBranch->nIndex);
 
         LogPrintf("CBlockIndex: %s\nProofRoot: %s\n", pindex->ToString().c_str(), CProofRoot::GetProofRoot(pindex->GetHeight()).ToUniValue().write(1,2).c_str());
         LogPrintf("txhash: %s\ncheckTx.GetHash(): %s\ncalculated merkle: %s\ncheckMerkle: %s\n", txHash.GetHex().c_str(), checkTx.GetHash().GetHex().c_str(), merkleRoot.GetHex().c_str(), checkMerkle.GetHex().c_str());

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -631,9 +631,10 @@ public:
 
     int32_t BlockNum()
     {
-        if (headerProof.proofSequence.size() && headerProof.proofSequence[0]->branchType == CMerkleBranchBase::BRANCH_MMRBLAKE_POWERNODE)
+        if (!headerProof.proofSequence.empty())
         {
-            return ((CMMRPowerNodeBranch *)(headerProof.proofSequence[0]))->nIndex;
+            if (const auto* p = std::get_if<CMMRPowerNodeBranch>(&headerProof.proofSequence[0]))
+                return p->nIndex;
         }
         return -1;
     }
@@ -651,12 +652,12 @@ public:
     uint256 GetBlockPower() const
     {
         int proofIdx = headerProof.proofSequence.size() == 2 ? 1 : 0;
-        if (headerProof.proofSequence.size() && headerProof.proofSequence[proofIdx]->branchType == CMerkleBranchBase::BRANCH_MMRBLAKE_POWERNODE)
+        if (!headerProof.proofSequence.empty())
         {
-            std::vector<uint256> &branch = ((CMMRPowerNodeBranch *)(headerProof.proofSequence[proofIdx]))->branch;
-            if (branch.size() >= 1)
+            if (const auto* p = std::get_if<CMMRPowerNodeBranch>(&headerProof.proofSequence[proofIdx]))
             {
-                return branch[0];
+                if (p->branch.size() >= 1)
+                    return p->branch[0];
             }
         }
         return uint256();
@@ -665,9 +666,10 @@ public:
     uint32_t GetBlockHeight() const
     {
         int proofIdx = headerProof.proofSequence.size() == 2 ? 1 : 0;
-        if (headerProof.proofSequence.size() && headerProof.proofSequence[proofIdx]->branchType == CMerkleBranchBase::BRANCH_MMRBLAKE_POWERNODE)
+        if (!headerProof.proofSequence.empty())
         {
-            return ((CMMRPowerNodeBranch *)(headerProof.proofSequence[proofIdx]))->nIndex;
+            if (const auto* p = std::get_if<CMMRPowerNodeBranch>(&headerProof.proofSequence[proofIdx]))
+                return p->nIndex;
         }
         return 0;
     }
@@ -756,9 +758,10 @@ public:
 
     int32_t BlockNum()
     {
-        if (headerProof.proofSequence.size() && headerProof.proofSequence[0]->branchType == CMerkleBranchBase::BRANCH_MMRBLAKE_POWERNODE)
+        if (!headerProof.proofSequence.empty())
         {
-            return ((CMMRPowerNodeBranch *)(headerProof.proofSequence[0]))->nIndex;
+            if (const auto* p = std::get_if<CMMRPowerNodeBranch>(&headerProof.proofSequence[0]))
+                return p->nIndex;
         }
         return -1;
     }
@@ -776,12 +779,12 @@ public:
     uint256 GetBlockPower() const
     {
         int proofIdx = headerProof.proofSequence.size() == 2 ? 1 : 0;
-        if (headerProof.proofSequence.size() && headerProof.proofSequence[proofIdx]->branchType == CMerkleBranchBase::BRANCH_MMRBLAKE_POWERNODE)
+        if (!headerProof.proofSequence.empty())
         {
-            std::vector<uint256> &branch = ((CMMRPowerNodeBranch *)(headerProof.proofSequence[proofIdx]))->branch;
-            if (branch.size() >= 1)
+            if (const auto* p = std::get_if<CMMRPowerNodeBranch>(&headerProof.proofSequence[proofIdx]))
             {
-                return branch[0];
+                if (p->branch.size() >= 1)
+                    return p->branch[0];
             }
         }
         return uint256();
@@ -790,9 +793,10 @@ public:
     uint32_t GetBlockHeight() const
     {
         int proofIdx = headerProof.proofSequence.size() == 2 ? 1 : 0;
-        if (headerProof.proofSequence.size() && headerProof.proofSequence[proofIdx]->branchType == CMerkleBranchBase::BRANCH_MMRBLAKE_POWERNODE)
+        if (!headerProof.proofSequence.empty())
         {
-            return ((CMMRPowerNodeBranch *)(headerProof.proofSequence[proofIdx]))->nIndex;
+            if (const auto* p = std::get_if<CMMRPowerNodeBranch>(&headerProof.proofSequence[proofIdx]))
+                return p->nIndex;
         }
         return 0;
     }

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -639,12 +639,12 @@ uint256 CPartialTransactionProof::GetPartialTransaction(CTransaction &outTx, boo
 
                 if (elHash.size() == 0 ||
                     components[0].elProof.proofSequence.size() != 1 ||
-                    components[0].elProof.proofSequence[0]->branchType != CMerkleBranchBase::BRANCH_MMRBLAKE_NODE ||
-                    elHash.size() != ((CMMRNodeBranch *)components[0].elProof.proofSequence[0])->nSize ||
-                    ((CMMRNodeBranch *)components[0].elProof.proofSequence[0])->nIndex != 0 ||
-                    ((CMMRNodeBranch *)components[0].elProof.proofSequence[0])->branch.size() == 0 ||
-                    TransactionMMView::GetProofBits(((CMMRNodeBranch *)components[0].elProof.proofSequence[0])->nIndex, elHash.size()).size() !=
-                            (((CMMRNodeBranch *)components[0].elProof.proofSequence[0])->branch.size() - (IsCapped() ? 1 : 0)))
+                    !std::holds_alternative<CMMRNodeBranch>(components[0].elProof.proofSequence[0]) ||
+                    elHash.size() != std::get<CMMRNodeBranch>(components[0].elProof.proofSequence[0]).nSize ||
+                    std::get<CMMRNodeBranch>(components[0].elProof.proofSequence[0]).nIndex != 0 ||
+                    std::get<CMMRNodeBranch>(components[0].elProof.proofSequence[0]).branch.size() == 0 ||
+                    TransactionMMView::GetProofBits(std::get<CMMRNodeBranch>(components[0].elProof.proofSequence[0]).nIndex, elHash.size()).size() !=
+                            (std::get<CMMRNodeBranch>(components[0].elProof.proofSequence[0]).branch.size() - (IsCapped() ? 1 : 0)))
                 {
                     // error
                     return uint256();
@@ -654,7 +654,7 @@ uint256 CPartialTransactionProof::GetPartialTransaction(CTransaction &outTx, boo
 
                 if (IsCapped())
                 {
-                    arith_uint256 mmrSizeHash = UintToArith256(*((CMMRNodeBranch *)components[0].elProof.proofSequence[0])->branch.rbegin());
+                    arith_uint256 mmrSizeHash = UintToArith256(*std::get<CMMRNodeBranch>(components[0].elProof.proofSequence[0]).branch.rbegin());
 
                     if (mmrSizeHash != arith_uint256(elHash.size()))
                     {
@@ -679,7 +679,7 @@ uint256 CPartialTransactionProof::GetPartialTransaction(CTransaction &outTx, boo
 
                     try
                     {
-                        for (auto &oneHash : ((CMMRNodeBranch *)components[0].elProof.proofSequence[0])->branch)
+                        for (auto &oneHash : std::get<CMMRNodeBranch>(components[0].elProof.proofSequence[0]).branch)
                         {
                             checkCount++;
                             if (UintToArith256(oneHash) <= checkLimit)
@@ -692,11 +692,10 @@ uint256 CPartialTransactionProof::GetPartialTransaction(CTransaction &outTx, boo
                         {
                             for (auto &oneBranch : txProof.proofSequence)
                             {
-                                if (oneBranch->branchType != CMerkleBranchBase::BRANCH_MMRBLAKE_NODE)
-                                {
+                                const auto* pNode = std::get_if<CMMRNodeBranch>(&oneBranch);
+                                if (!pNode)
                                     break;
-                                }
-                                for (auto &oneHash : ((CMMRNodeBranch *)oneBranch)->branch)
+                                for (auto &oneHash : pNode->branch)
                                 {
                                     checkCount++;
                                     if (UintToArith256(oneHash) <= checkLimit)
@@ -731,9 +730,9 @@ uint256 CPartialTransactionProof::GetPartialTransaction(CTransaction &outTx, boo
                 {
                     if (components[i].CheckProof() != txRoot ||
                         !elHash.count({components[i].elType, components[i].elIdx}) ||
-                        elHash[{components[i].elType, components[i].elIdx}] != ((CMMRNodeBranch *)components[i].elProof.proofSequence[0])->nIndex ||
-                        TransactionMMView::GetProofBits(((CMMRNodeBranch *)components[i].elProof.proofSequence[0])->nIndex, elHash.size()).size() !=
-                            (((CMMRNodeBranch *)components[i].elProof.proofSequence[0])->branch.size() - (IsCapped() ? 1 : 0)))
+                        elHash[{components[i].elType, components[i].elIdx}] != std::get<CMMRNodeBranch>(components[i].elProof.proofSequence[0]).nIndex ||
+                        TransactionMMView::GetProofBits(std::get<CMMRNodeBranch>(components[i].elProof.proofSequence[0]).nIndex, elHash.size()).size() !=
+                            (std::get<CMMRNodeBranch>(components[i].elProof.proofSequence[0]).branch.size() - (IsCapped() ? 1 : 0)))
                     {
                         checkOK = false;
                         break;

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -1280,7 +1280,9 @@ public:
         if (capped &&
             retVal.elProof.proofSequence.size())
         {
-            ((CMMRNodeBranch *)retVal.elProof.proofSequence[0])->branch.push_back(ArithToUint256(arith_uint256(txView.size())));
+            auto* p = std::get_if<CMMRNodeBranch>(&retVal.elProof.proofSequence[0]);
+            if (p)
+                p->branch.push_back(ArithToUint256(arith_uint256(txView.size())));
         }
         return retVal;
     }
@@ -1467,8 +1469,8 @@ public:
                ((type == TYPE_ETH) ||
                 (TYPE_PBAAS == type &&
                  txProof.proofSequence.size() >= 3 &&
-                 txProof.proofSequence[1]->branchType == CMerkleBranchBase::BRANCH_MMRBLAKE_NODE &&
-                 txProof.proofSequence[2]->branchType == CMerkleBranchBase::BRANCH_MMRBLAKE_POWERNODE));
+                 std::holds_alternative<CMMRNodeBranch>(txProof.proofSequence[1]) &&
+                 std::holds_alternative<CMMRPowerNodeBranch>(txProof.proofSequence[2])));
     }
 
     bool IsValid() const
@@ -1478,7 +1480,7 @@ public:
 
     bool IsMultipart() const
     {
-        return IsValid() && txProof.proofSequence.size() == 1 && txProof.proofSequence[0]->branchType == CMerkleBranchBase::BRANCH_MULTIPART;
+        return IsValid() && txProof.proofSequence.size() == 1 && std::holds_alternative<CMultiPartProof>(txProof.proofSequence[0]);
     }
 
     std::vector<CPartialTransactionProof> BreakApart(int maxChunkSize=(CScript::MAX_SCRIPT_ELEMENT_SIZE-256)) const
@@ -1505,7 +1507,7 @@ public:
     {
         if ((type == TYPE_PBAAS || type == TYPE_FULLTX) && IsChainProof())
         {
-            std::vector<uint256> &branch = ((CMMRNodeBranch *)(txProof.proofSequence[1]))->branch;
+            const std::vector<uint256> &branch = std::get<CMMRNodeBranch>(txProof.proofSequence[1]).branch;
             if (branch.size() == 1)
             {
                 return branch[0];
@@ -1518,7 +1520,7 @@ public:
     {
         if (type == TYPE_PBAAS && IsChainProof())
         {
-            std::vector<uint256> &branch = ((CMMRPowerNodeBranch *)(txProof.proofSequence[2]))->branch;
+            const std::vector<uint256> &branch = std::get<CMMRPowerNodeBranch>(txProof.proofSequence[2]).branch;
             if (branch.size() >= 1)
             {
                 return branch[0];
@@ -1531,7 +1533,7 @@ public:
     {
         if (type == TYPE_PBAAS && IsChainProof())
         {
-            std::vector<uint256> &branch = ((CMMRPowerNodeBranch *)(txProof.proofSequence[2]))->branch;
+            const std::vector<uint256> &branch = std::get<CMMRPowerNodeBranch>(txProof.proofSequence[2]).branch;
             if (branch.size() >= 1)
             {
                 return branch.back();
@@ -1544,7 +1546,7 @@ public:
     {
         if ((type == TYPE_PBAAS || type == TYPE_FULLTX) && IsChainProof())
         {
-            return ((CMMRPowerNodeBranch *)(txProof.proofSequence[2]))->nIndex;
+            return std::get<CMMRPowerNodeBranch>(txProof.proofSequence[2]).nIndex;
         }
         return 0;
     }
@@ -1553,7 +1555,7 @@ public:
     {
         if ((type == TYPE_PBAAS || type == TYPE_FULLTX) && IsChainProof())
         {
-            return ((CMMRPowerNodeBranch *)(txProof.proofSequence[2]))->nSize - 1;
+            return std::get<CMMRPowerNodeBranch>(txProof.proofSequence[2]).nSize - 1;
         }
         return 0;
     }


### PR DESCRIPTION
## Here's a summary of what was done across 7 files:

### Credit: @claudio

**Violation 1 — Owning raw pointer** (`std::vector<CMerkleBranchBase*>`) → Replaced with `std::vector<ProofEntry>` where `ProofEntry = std::variant<CBTCMerkleBranch, CMMRNodeBranch, CMMRPowerNodeBranch, CETHPATRICIABranch, CMultiPartProof>`. Destruction is now automatic and type-correct.

**Violation 2 — Manual cleanup path** (`DeleteProofSequence` / `DeleteProofSequenceEntry` with pop_back loops) → Both collapse to `proofSequence.clear()` and `proofSequence.erase(begin+index)`. The dtor is now the defaulted variant destructor.

**Violation 3 — Cast-delete / cast-access** (`delete (CETHPATRICIABranch*)pProof` etc.) → All 5 `operator<<` overloads use `emplace_back`. All accessor sites in `mmr.cpp`, `core_write.cpp`, `pbaas/notarization.cpp`, `primitives/block.h`, `primitives/transaction.h`, and `primitives/transaction.cpp` now use `std::get_if<T>`, `std::get<T>`, or `std::holds_alternative<T>` — all type-safe and unexpressible as the wrong type.

| File | Nature of change |
|---|---|
| `src/mmr.h` | `proofSequence` type, copy/dtor defaulted, `SerializationOp` rewritten, `IsMultiPart()` |
| `src/mmr.cpp` | `DeleteProofSequence`, `DeleteProofSequenceEntry`, all 5 `operator<<`, `CheckProof`, `GetNativeAddress`, `CheckStorageKey`, `CMultiPartProof` ctor + `BreakToChunks` |
| `src/core_write.cpp` | `ToUniValue()` switch-cast → `std::get_if` chain |
| `src/pbaas/notarization.cpp` | Debug logging block cast → `std::get_if` |
| `src/primitives/block.h` | `BlockNum`, `GetBlockPower`, `GetBlockHeight` in both `CBlockHeaderProof` and `CBlockHeaderAndProof` |
| `src/primitives/transaction.h` | `GetComponentProof`, `IsChainProof`, `IsMultipart`, `GetBlockHash`, `GetBlockPower`, `GetRootPower`, `GetBlockHeight`, `GetProofHeight` |
| `src/primitives/transaction.cpp` | `CheckPartialTransaction` — type checks and branch iteration |


